### PR TITLE
🛡️ Sentinel: [HIGH] Add ALLOWED_NAMESPACES to restrict KV access

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2024-05-22 - [Worker] Insecure Direct Object Reference in KV Namespaces
+**Vulnerability:** The Cloudflare Worker implementation exposed all bound KV namespaces via a generic `/:namespace/:slug` route. This meant any internal KV namespace (e.g., `KV_SECRETS`) bound to the worker was publicly accessible if the attacker guessed the namespace name.
+**Learning:** Dynamic resource mapping (like `/:namespace` -> `KV_NAMESPACE`) is convenient but dangerous if it bypasses explicit access controls.
+**Prevention:** Always implement an allowlist for dynamic resource access. In this case, `ALLOWED_NAMESPACES` environment variable was added to restrict access to only intended public namespaces.

--- a/doc/cloudflare-workers.md
+++ b/doc/cloudflare-workers.md
@@ -143,6 +143,7 @@ Configure via Dashboard under **Settings** → **Variables and Secrets**:
 | Variable | Description | Example |
 |---|---|---|
 | `ALLOWED_ORIGINS` | Comma-separated list of allowed CORS origins | `https://example.com,https://app.example.com` |
+| `ALLOWED_NAMESPACES` | Comma-separated list of exposed KV namespaces (if unset, all matching bindings are exposed) | `content,blog-posts` |
 
 ### CORS Behavior
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -133,6 +133,31 @@ describe("Worker — KV namespace resolution", () => {
     const env: WorkerEnv = { KV_BROKEN: "not-an-object" };
     expect(resolveKV(env, "broken")).toBeNull();
   });
+
+  it("should resolve allowed namespace when allowlist is set", () => {
+    const env: WorkerEnv = {
+      KV_CONTENT: { get: async () => null },
+      ALLOWED_NAMESPACES: "content,pages",
+    };
+    expect(resolveKV(env, "content")).toBe(env.KV_CONTENT);
+  });
+
+  it("should return null for disallowed namespace when allowlist is set", () => {
+    const env: WorkerEnv = {
+      KV_SECRET: { get: async () => null },
+      ALLOWED_NAMESPACES: "content,pages",
+    };
+    // "secret" maps to KV_SECRET but is not in ALLOWED_NAMESPACES
+    expect(resolveKV(env, "secret")).toBeNull();
+  });
+
+  it("should handle spaces in allowlist", () => {
+    const env: WorkerEnv = {
+      KV_PAGES: { get: async () => null },
+      ALLOWED_NAMESPACES: "content, pages , blog",
+    };
+    expect(resolveKV(env, "pages")).toBe(env.KV_PAGES);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/worker/utils.ts
+++ b/worker/utils.ts
@@ -54,6 +54,14 @@ export function isValidNamespace(ns: string): boolean {
  * Returns `null` if the binding doesn't exist or isn't KV-like.
  */
 export function resolveKV(env: WorkerEnv, namespace: string): KVLike | null {
+  // If allowed namespaces are configured, check against the list.
+  if (env.ALLOWED_NAMESPACES) {
+    const allowed = env.ALLOWED_NAMESPACES.split(",").map((n) => n.trim());
+    if (!allowed.includes(namespace)) {
+      return null;
+    }
+  }
+
   const bindingName = `KV_${namespace.toUpperCase().replace(/-/g, "_")}`;
   const binding = (env as Record<string, unknown>)[bindingName];
   if (binding && typeof binding === "object" && "get" in binding) {
@@ -66,6 +74,8 @@ export function resolveKV(env: WorkerEnv, namespace: string): KVLike | null {
 export interface WorkerEnv {
   /** Comma-separated list of allowed origins. */
   ALLOWED_ORIGINS?: string;
+  /** Comma-separated list of allowed namespaces. If unset, all matching KV bindings are exposed. */
+  ALLOWED_NAMESPACES?: string;
   /**
    * KV namespace bindings are added dynamically via the Cloudflare Dashboard.
    * Convention: `KV_<NAMESPACE>` (e.g., `KV_CONTENT`, `KV_PAGES`).


### PR DESCRIPTION
This PR addresses a potential security risk where all KV namespaces bound to the worker were automatically exposed via the generic `/:namespace/:slug` route.

### Changes
- Modified `worker/utils.ts` to check `ALLOWED_NAMESPACES` environment variable in `resolveKV`.
- Updated `WorkerEnv` type definition.
- Added comprehensive tests in `tests/worker.test.ts`.
- Documented the new variable in `doc/cloudflare-workers.md`.

### Security Impact
- **Severity:** HIGH (Insecure Direct Object Reference / Information Disclosure)
- **Mitigation:** Allows administrators to explicitly allowlist public KV namespaces, protecting internal data.

---
*PR created automatically by Jules for task [2144374112661320752](https://jules.google.com/task/2144374112661320752) started by @murelux*