### PR TITLE
🛡️ Sentinel: Fix SSRF bypass with IPv4-mapped IPv6 hex addresses

### DIFF
--- a/src/reader.ts
+++ b/src/reader.ts
@@ -80,10 +80,38 @@ export function isPrivateHostname(hostname: string): boolean {
   if (/^fc/i.test(lower) || /^fd/i.test(lower)) return true;
   if (/^fe[89ab]/i.test(lower)) return true;
 
-  // IPv4-mapped IPv6: ::ffff:A.B.C.D
-  const v4Mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-  if (v4Mapped) {
-    return isPrivateHostname(v4Mapped[1]);
+  // IPv4-mapped IPv6: ::ffff:A.B.C.D or ::ffff:hex
+  if (lower.startsWith("::ffff:")) {
+    const remainder = lower.slice(7);
+
+    // Case 1: Dot-decimal notation (::ffff:127.0.0.1)
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(remainder)) {
+      return isPrivateHostname(remainder);
+    }
+
+    // Case 2: Hex notation (::ffff:7f00:1)
+    // Convert hex parts to IPv4 string
+    // e.g. "7f00:1" -> "127.0.0.1"
+    const hexParts = remainder.split(":");
+    if (hexParts.length <= 2) {
+      try {
+        let ipInt = 0;
+        for (const part of hexParts) {
+          if (!/^[0-9a-f]{1,4}$/.test(part)) return false; // Invalid hex
+          ipInt = (ipInt << 16) | Number.parseInt(part, 16);
+        }
+
+        // Convert 32-bit integer to dot-decimal string
+        // Use unsigned right shift to handle negative numbers from bitwise ops
+        const p1 = (ipInt >>> 24) & 255;
+        const p2 = (ipInt >>> 16) & 255;
+        const p3 = (ipInt >>> 8) & 255;
+        const p4 = ipInt & 255;
+        return isPrivateHostname(`${p1}.${p2}.${p3}.${p4}`);
+      } catch {
+        // Fall through to false if parsing fails
+      }
+    }
   }
 
   return false;

--- a/tests/security_ssrf_ipv6.test.ts
+++ b/tests/security_ssrf_ipv6.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { isPrivateHostname } from "../src/reader";
+
+describe("SSRF Protection - IPv6 Bypass", () => {
+  it("should block standard IPv4 private addresses", () => {
+    expect(isPrivateHostname("127.0.0.1")).toBe(true);
+    expect(isPrivateHostname("10.0.0.5")).toBe(true);
+    expect(isPrivateHostname("192.168.1.1")).toBe(true);
+  });
+
+  it("should block standard IPv6 private addresses", () => {
+    expect(isPrivateHostname("::1")).toBe(true);
+    expect(isPrivateHostname("[::1]")).toBe(true);
+    expect(isPrivateHostname("fc00::1")).toBe(true);
+  });
+
+  it("should block standard IPv4-mapped IPv6 addresses", () => {
+    expect(isPrivateHostname("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateHostname("[::ffff:127.0.0.1]")).toBe(true);
+  });
+
+  it("should block hex-encoded IPv4-mapped IPv6 addresses (VULNERABILITY)", () => {
+    // 127.0.0.1 = 7f 00 00 01
+    // ::ffff:7f00:1
+    // This currently fails (returns false) but should be true
+    expect(isPrivateHostname("::ffff:7f00:1")).toBe(true);
+    expect(isPrivateHostname("[::ffff:7f00:1]")).toBe(true);
+
+    // 192.168.1.1 = c0 a8 01 01
+    // ::ffff:c0a8:101
+    expect(isPrivateHostname("::ffff:c0a8:101")).toBe(true);
+  });
+
+  it("should allow public addresses", () => {
+    expect(isPrivateHostname("8.8.8.8")).toBe(false);
+    expect(isPrivateHostname("google.com")).toBe(false);
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: Fix SSRF bypass with IPv4-mapped IPv6 hex addresses

🚨 **Severity:** HIGH
💡 **Vulnerability:** The previous implementation of `isPrivateHostname` only checked for dot-decimal notation of IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`). Attackers could bypass this check using hexadecimal notation (e.g., `::ffff:7f00:1`), allowing access to internal services via SSRF.
🎯 **Impact:** Potential unauthorized access to internal network resources or services bound to localhost.
🔧 **Fix:** Enhanced `isPrivateHostname` in `src/reader.ts` to detect and parse hex-encoded IPv4-mapped IPv6 addresses, converting them to standard IPv4 dot-decimal notation for validation against private IP ranges.
✅ **Verification:** Added `tests/security_ssrf_ipv6.test.ts` which confirms that `::ffff:7f00:1` is now correctly blocked, while valid public addresses remain accessible. Existing tests pass (excluding unrelated pre-existing failures).

---
*PR created automatically by Jules for task [3221587362205749736](https://jules.google.com/task/3221587362205749736) started by @murelux*