### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in readFrontMatter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,18 @@ export interface ParseOptions {
    * @default false
    */
   excerpt?: boolean | ExcerptOptions;
+
+  /**
+   * Allow reading from remote URLs when using `readFrontMatter`.
+   * @default false
+   */
+  allowRemoteUrls?: boolean;
+
+  /**
+   * Base directory to restrict local file reads to when using `readFrontMatter`.
+   * Prevents path traversal vulnerabilities.
+   */
+  baseDir?: string;
 }
 
 /**
@@ -513,7 +525,7 @@ export async function readFrontMatter<T = Record<string, unknown>>(
   path: string | URL,
   options?: ParseOptions,
 ): Promise<ParseResult<T>> {
-  const content = await readFileContent(path);
+  const content = await readFileContent(path, options);
   return parseFrontMatter<T>(content, options);
 }
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -122,6 +122,48 @@ export function isPrivateHostname(hostname: string): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * Validates that a file path resolves within the allowed base directory.
+ * Prevents path traversal vulnerabilities.
+ */
+async function validatePath(path: string | URL, baseDir?: string): Promise<void> {
+  if (!baseDir) return;
+
+  const { resolve, sep } = await import("node:path");
+
+  let filePath: string;
+  if (typeof path === "string") {
+    // If it's a file:// URL string, convert it to a path
+    if (path.startsWith("file://")) {
+      const { fileURLToPath } = await import("node:url");
+      filePath = fileURLToPath(path);
+    } else {
+      filePath = path;
+    }
+  } else {
+    // It's a URL object
+    if (path.protocol === "file:") {
+      const { fileURLToPath } = await import("node:url");
+      filePath = fileURLToPath(path);
+    } else {
+      // Non-file URLs (e.g. HTTP) are handled separately in readFileContent
+      return;
+    }
+  }
+
+  const resolvedBase = resolve(baseDir);
+  const resolvedPath = resolve(filePath);
+
+  // Ensure basePrefix always ends with a separator, avoiding double slashes if resolvedBase is root
+  const basePrefix = resolvedBase.endsWith(sep) ? resolvedBase : resolvedBase + sep;
+
+  // Check if the resolved path starts with the base directory + separator
+  // or exactly equals the base directory
+  if (!resolvedPath.startsWith(basePrefix) && resolvedPath !== resolvedBase) {
+    throw new Error(`Path traversal blocked: ${String(path)} is outside base directory ${baseDir}`);
+  }
+}
+
+/**
  * Read content from a file path or URL.
  *
  * Supports:
@@ -134,7 +176,7 @@ export function isPrivateHostname(hostname: string): boolean {
  */
 export async function readFileContent(
   path: string | URL,
-  options?: { allowRemoteUrls?: boolean },
+  options?: { allowRemoteUrls?: boolean; baseDir?: string },
 ): Promise<string> {
   // 1. Fetch (HTTP/HTTPS) - prioritize for all runtimes
   if (
@@ -148,6 +190,9 @@ export async function readFileContent(
     }
     return fetchContent(path);
   }
+
+  // Validate local file path against baseDir (if provided)
+  await validatePath(path, options?.baseDir);
 
   // 2. Bun (Local Files & file: URLs)
   if (typeof Bun !== "undefined") {

--- a/tests/fixtures/valid.md
+++ b/tests/fixtures/valid.md
@@ -1,0 +1,4 @@
+---
+title: test
+---
+content

--- a/tests/path-traversal.test.ts
+++ b/tests/path-traversal.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolve, join } from "node:path";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { readFrontMatter } from "../src/index.js";
+
+describe("Path Traversal Protection", () => {
+  it("should allow reading files within the base directory", async () => {
+    const baseDir = resolve(__dirname, "fixtures");
+    mkdirSync(baseDir, { recursive: true });
+
+    const validFile = join(baseDir, "valid.md");
+    writeFileSync(validFile, "---\ntitle: test\n---\ncontent", "utf-8");
+
+    const result = await readFrontMatter(validFile, { baseDir });
+    expect(result.data).toEqual({ title: "test" });
+  });
+
+  it("should block reading files outside the base directory via relative path", async () => {
+    const baseDir = resolve(__dirname, "fixtures");
+    const validFile = join(baseDir, "valid.md");
+
+    const outsideFile = join(baseDir, "../file.test.ts"); // A file outside baseDir
+
+    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+  });
+
+  it("should block reading files outside the base directory via absolute path", async () => {
+    const baseDir = resolve(__dirname, "fixtures");
+
+    // An absolute path outside baseDir
+    const outsideFile = resolve(__dirname, "file.test.ts");
+
+    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+  });
+
+  it("should block path traversal attempts using ../", async () => {
+    const baseDir = resolve(__dirname, "fixtures");
+
+    // Path string that attempts to traverse out
+    const traversalPath = join(baseDir, "../../package.json");
+
+    await expect(readFrontMatter(traversalPath, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+  });
+
+  it("should block path traversal using file:// URLs", async () => {
+    const baseDir = resolve(__dirname, "fixtures");
+    const traversalURL = new URL("file://" + resolve(__dirname, "../../package.json"));
+
+    await expect(readFrontMatter(traversalURL, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+  });
+
+  it("should allow if baseDir is exactly the file path", async () => {
+    const baseDir = resolve(__dirname, "fixtures/valid.md");
+    const result = await readFrontMatter(baseDir, { baseDir });
+    expect(result.data).toEqual({ title: "test" });
+  });
+
+  it("should allow reading if baseDir is not provided", async () => {
+    const outsideFile = resolve(__dirname, "file.test.ts");
+
+    // Should not throw path traversal error, might throw parsing error but that's fine
+    await expect(readFrontMatter(outsideFile)).resolves.toBeDefined();
+  });
+});

--- a/tests/path-traversal.test.ts
+++ b/tests/path-traversal.test.ts
@@ -1,6 +1,6 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolve, join } from "node:path";
-import { writeFileSync, mkdirSync } from "node:fs";
 import { readFrontMatter } from "../src/index.js";
 
 describe("Path Traversal Protection", () => {
@@ -17,11 +17,13 @@ describe("Path Traversal Protection", () => {
 
   it("should block reading files outside the base directory via relative path", async () => {
     const baseDir = resolve(__dirname, "fixtures");
-    const validFile = join(baseDir, "valid.md");
+    const _validFile = join(baseDir, "valid.md");
 
     const outsideFile = join(baseDir, "../file.test.ts"); // A file outside baseDir
 
-    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(
+      /Path traversal blocked/,
+    );
   });
 
   it("should block reading files outside the base directory via absolute path", async () => {
@@ -30,7 +32,9 @@ describe("Path Traversal Protection", () => {
     // An absolute path outside baseDir
     const outsideFile = resolve(__dirname, "file.test.ts");
 
-    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+    await expect(readFrontMatter(outsideFile, { baseDir })).rejects.toThrow(
+      /Path traversal blocked/,
+    );
   });
 
   it("should block path traversal attempts using ../", async () => {
@@ -39,14 +43,18 @@ describe("Path Traversal Protection", () => {
     // Path string that attempts to traverse out
     const traversalPath = join(baseDir, "../../package.json");
 
-    await expect(readFrontMatter(traversalPath, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+    await expect(readFrontMatter(traversalPath, { baseDir })).rejects.toThrow(
+      /Path traversal blocked/,
+    );
   });
 
   it("should block path traversal using file:// URLs", async () => {
     const baseDir = resolve(__dirname, "fixtures");
-    const traversalURL = new URL("file://" + resolve(__dirname, "../../package.json"));
+    const traversalURL = new URL(`file://${resolve(__dirname, "../../package.json")}`);
 
-    await expect(readFrontMatter(traversalURL, { baseDir })).rejects.toThrow(/Path traversal blocked/);
+    await expect(readFrontMatter(traversalURL, { baseDir })).rejects.toThrow(
+      /Path traversal blocked/,
+    );
   });
 
   it("should allow if baseDir is exactly the file path", async () => {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in readFrontMatter

🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `readFrontMatter` API did not validate local file paths, allowing arbitrary file reading via path traversal (e.g., passing `"../../etc/passwd"` to `readFrontMatter`).
🎯 **Impact**: Attackers could potentially read sensitive files on the server running this application.
🔧 **Fix**: Extended `ParseOptions` to include `baseDir` and `allowRemoteUrls`. Added a `validatePath` helper to check that the resolved path is within the resolved `baseDir` before reading the file content.
✅ **Verification**: Tests added in `tests/path-traversal.test.ts`.

---
*PR created automatically by Jules for task [6005538257023671436](https://jules.google.com/task/6005538257023671436) started by @murelux*