### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Local File Reads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The Cloudflare Worker implementation exposed all bound KV namespaces via a generic `/:namespace/:slug` route. This meant any internal KV namespace (e.g., `KV_SECRETS`) bound to the worker was publicly accessible if the attacker guessed the namespace name.
 **Learning:** Dynamic resource mapping (like `/:namespace` -> `KV_NAMESPACE`) is convenient but dangerous if it bypasses explicit access controls.
 **Prevention:** Always implement an allowlist for dynamic resource access. In this case, `ALLOWED_NAMESPACES` environment variable was added to restrict access to only intended public namespaces.
+
+## 2024-05-23 - [Reader] Path Traversal in Local File Reads
+**Vulnerability:** The `readFileContent` function lacked boundaries for local file reads, making the library susceptible to path traversal/LFI vulnerabilities if user input was directly passed as the `path`.
+**Learning:** Even utility libraries should provide robust "jail" options like `baseDir` to enforce access boundaries when dealing with file I/O on behalf of upstream applications.
+**Prevention:** Implemented a `baseDir` option in `ParseOptions` that uses `node:path` to resolve and normalize paths, strictly enforcing that any read file resides within the allowed base directory.

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,17 @@ export function hasFrontMatter(
  */
 export interface ParseOptions {
   /**
+   * Optional base directory to restrict local file reads and prevent path traversal.
+   */
+  baseDir?: string | URL;
+
+  /**
+   * Whether to allow fetching remote URLs.
+   * @default false
+   */
+  allowRemoteUrls?: boolean;
+
+  /**
    * Optional Valibot schema to validate the parsed data against.
    * When provided, the returned `data` is typed & validated.
    *
@@ -513,7 +524,7 @@ export async function readFrontMatter<T = Record<string, unknown>>(
   path: string | URL,
   options?: ParseOptions,
 ): Promise<ParseResult<T>> {
-  const content = await readFileContent(path);
+  const content = await readFileContent(path, options);
   return parseFrontMatter<T>(content, options);
 }
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -134,7 +134,7 @@ export function isPrivateHostname(hostname: string): boolean {
  */
 export async function readFileContent(
   path: string | URL,
-  options?: { allowRemoteUrls?: boolean },
+  options?: { allowRemoteUrls?: boolean; baseDir?: string | URL },
 ): Promise<string> {
   // 1. Fetch (HTTP/HTTPS) - prioritize for all runtimes
   if (
@@ -147,6 +147,30 @@ export async function readFileContent(
       );
     }
     return fetchContent(path);
+  }
+
+  // Path Traversal Protection for local files
+  if (options?.baseDir) {
+    const { resolve, sep } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    const getPathStr = (p: string | URL) =>
+      p instanceof URL ? (p.protocol === "file:" ? fileURLToPath(p) : p.href) : p;
+
+    const baseDirPath = getPathStr(options.baseDir);
+    const requestedPath = getPathStr(path);
+
+    const absoluteBase = resolve(baseDirPath);
+    // Resolve against absoluteBase so relative paths are treated as relative to baseDir
+    const absoluteRequested = resolve(absoluteBase, requestedPath);
+
+    // Ensure the resolved requested path is inside the absoluteBase
+    // Adding `sep` ensures it's strictly inside the directory (avoids /baseDir-foo matching /baseDir)
+    if (!absoluteRequested.startsWith(absoluteBase + sep) && absoluteRequested !== absoluteBase) {
+      throw new Error(`Path traversal detected: ${String(path)} is outside base directory`);
+    }
+
+    path = absoluteRequested;
   }
 
   // 2. Bun (Local Files & file: URLs)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `readFileContent` function lacked boundaries for local file reads, making the library susceptible to path traversal/LFI vulnerabilities if user input was directly passed as the `path`.
🎯 Impact: Attackers could read sensitive files outside the intended directory.
🔧 Fix: Implemented a `baseDir` option in `ParseOptions` that uses `node:path` to resolve and normalize paths, strictly enforcing that any read file resides within the allowed base directory.
✅ Verification: Ensure the tests pass and no regression was introduced.

---
*PR created automatically by Jules for task [8252794745671105830](https://jules.google.com/task/8252794745671105830) started by @murelux*