### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Reading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The Cloudflare Worker implementation exposed all bound KV namespaces via a generic `/:namespace/:slug` route. This meant any internal KV namespace (e.g., `KV_SECRETS`) bound to the worker was publicly accessible if the attacker guessed the namespace name.
 **Learning:** Dynamic resource mapping (like `/:namespace` -> `KV_NAMESPACE`) is convenient but dangerous if it bypasses explicit access controls.
 **Prevention:** Always implement an allowlist for dynamic resource access. In this case, `ALLOWED_NAMESPACES` environment variable was added to restrict access to only intended public namespaces.
+
+## 2025-02-20 - [Reader] Path Traversal in Local File Reads
+**Vulnerability:** The `readFrontMatter` and `readFrontMatterMany` functions allowed reading any local file accessible by the runtime process. An attacker who controls the `path` argument could exploit this to perform Local File Inclusion (LFI) and read sensitive files outside of the intended directory (e.g., `../../../../etc/passwd`).
+**Learning:** Any file reading utility that accepts user-provided paths must implement directory traversal protection to restrict reads to an intended base directory.
+**Prevention:** Introduce a `baseDir` option to strictly enforce that the target file path remains within the resolved base directory boundaries using absolute path comparisons.

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,16 @@ export interface ParseOptions {
    * @default false
    */
   excerpt?: boolean | ExcerptOptions;
+
+  /**
+   * Base directory to restrict local file reads. Prevents path traversal vulnerabilities.
+   */
+  baseDir?: string;
+
+  /**
+   * Allow fetching remote URLs.
+   */
+  allowRemoteUrls?: boolean;
 }
 
 /**
@@ -513,7 +523,7 @@ export async function readFrontMatter<T = Record<string, unknown>>(
   path: string | URL,
   options?: ParseOptions,
 ): Promise<ParseResult<T>> {
-  const content = await readFileContent(path);
+  const content = await readFileContent(path, options);
   return parseFrontMatter<T>(content, options);
 }
 

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -134,7 +134,7 @@ export function isPrivateHostname(hostname: string): boolean {
  */
 export async function readFileContent(
   path: string | URL,
-  options?: { allowRemoteUrls?: boolean },
+  options?: { allowRemoteUrls?: boolean; baseDir?: string },
 ): Promise<string> {
   // 1. Fetch (HTTP/HTTPS) - prioritize for all runtimes
   if (
@@ -147,6 +147,29 @@ export async function readFileContent(
       );
     }
     return fetchContent(path);
+  }
+
+  if (options?.baseDir) {
+    let filePathStr = "";
+    if (typeof path === "string") {
+      filePathStr = path;
+    } else if (path.protocol === "file:") {
+      const { fileURLToPath } = await import("node:url");
+      filePathStr = fileURLToPath(path);
+    }
+
+    if (filePathStr) {
+      const { resolve, relative, isAbsolute } = await import("node:path");
+      const resolvedBase = resolve(options.baseDir);
+      const resolvedPath = resolve(filePathStr);
+      const rel = relative(resolvedBase, resolvedPath);
+
+      if (rel.startsWith("..") || isAbsolute(rel)) {
+        throw new Error(
+          `Path traversal detected: ${String(path)} is outside base directory ${options.baseDir}`,
+        );
+      }
+    }
   }
 
   // 2. Bun (Local Files & file: URLs)

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -78,6 +78,23 @@ describe("readFrontMatter", () => {
     expect(result.content).toContain("Just markdown");
   });
 
+  it("should prevent path traversal when baseDir is configured", async () => {
+    // Try to read a file outside the base directory using string path
+    await expect(
+      readFrontMatter(join(TEST_DIR, "../package.json"), { baseDir: TEST_DIR }),
+    ).rejects.toThrow(/Path traversal detected/);
+
+    // Try to read a file outside the base directory using URL
+    const fileUrl = pathToFileURL(resolve(join(TEST_DIR, "../package.json")));
+    await expect(readFrontMatter(fileUrl, { baseDir: TEST_DIR })).rejects.toThrow(
+      /Path traversal detected/,
+    );
+
+    // Reading a file inside should still work
+    const result = await readFrontMatter(FILE_1, { baseDir: TEST_DIR });
+    expect(result.isEmpty).toBe(false);
+  });
+
   it("should isolate errors in readFrontMatterMany", async () => {
     const results = await readFrontMatterMany([FILE_1, "nonexistent.md", FILE_2]);
     expect(results).toHaveLength(3);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `readFrontMatter` and `readFrontMatterMany` functions allowed reading any local file accessible by the runtime process. An attacker who controls the `path` argument could exploit this to perform Local File Inclusion (LFI) and read sensitive files outside of the intended directory (e.g., `../../../../etc/passwd`).
🎯 Impact: This could lead to unauthorized access to sensitive system files, environment variables, or other restricted data.
🔧 Fix: Introduced a `baseDir` option in `ParseOptions` to strictly enforce that the target file path remains within the resolved base directory boundaries using absolute path comparisons. Updates were made to `src/reader.ts` to perform this validation before reading local files.
✅ Verification: Added a test case in `tests/file.test.ts` to verify that path traversal attempts are correctly blocked when `baseDir` is configured.

Additionally, added an entry to `.jules/sentinel.md` documenting this security learning and prevention strategy.

---
*PR created automatically by Jules for task [4094930618469887310](https://jules.google.com/task/4094930618469887310) started by @murelux*