### PR TITLE
🛡️ Sentinel: [HIGH] Add baseDir path traversal protection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The Cloudflare Worker implementation exposed all bound KV namespaces via a generic `/:namespace/:slug` route. This meant any internal KV namespace (e.g., `KV_SECRETS`) bound to the worker was publicly accessible if the attacker guessed the namespace name.
 **Learning:** Dynamic resource mapping (like `/:namespace` -> `KV_NAMESPACE`) is convenient but dangerous if it bypasses explicit access controls.
 **Prevention:** Always implement an allowlist for dynamic resource access. In this case, `ALLOWED_NAMESPACES` environment variable was added to restrict access to only intended public namespaces.
+
+## 2024-03-06 - [File System] Path Traversal in File Reading
+**Vulnerability:** The `readFileContent` function in `@quill/proteus` accepted user-supplied paths without restricting them to a base directory. While this is typical for utility functions, if a developer passed a raw user-supplied path directly into `readFrontMatter`, an attacker could supply `../../etc/passwd` to read arbitrary files from the host server.
+**Learning:** Functions that read files and may be used with user input should provide an opt-in or default mechanism to enforce a secure directory jail or base path to prevent path traversal / LFI.
+**Prevention:** Added a `baseDir` property to `ParseOptions` that uses `node:path` to resolve paths and checks if the relative path `rel.startsWith("..")` or is an absolute path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,14 @@ export interface ParseOptions {
    * @default false
    */
   allowRemoteUrls?: boolean;
+
+  /**
+   * Restrict local file reads to paths within this directory.
+   * Prevents path traversal vulnerabilities when reading user-supplied paths.
+   *
+   * Has no effect when reading remote URLs.
+   */
+  baseDir?: string | URL;
 }
 
 /**
@@ -569,6 +577,7 @@ export async function readFrontMatter<T = Record<string, unknown>>(
 ): Promise<ParseResult<T>> {
   const content = await readFileContent(path, {
     allowRemoteUrls: options?.allowRemoteUrls ?? false,
+    baseDir: options?.baseDir,
   });
   return parseFrontMatter<T>(content, options);
 }

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -134,7 +134,7 @@ export function isPrivateHostname(hostname: string): boolean {
  */
 export async function readFileContent(
   path: string | URL,
-  options?: { allowRemoteUrls?: boolean },
+  options?: { allowRemoteUrls?: boolean; baseDir?: string | URL },
 ): Promise<string> {
   // 1. Fetch (HTTP/HTTPS) - prioritize for all runtimes
   if (
@@ -147,6 +147,39 @@ export async function readFileContent(
       );
     }
     return fetchContent(path);
+  }
+
+  // Enforce baseDir path traversal protection for local files
+  if (options?.baseDir) {
+    const { resolve, relative, isAbsolute } = await import("node:path");
+    const { fileURLToPath } = await import("node:url");
+
+    let resolvedBaseDir: string;
+    if (typeof options.baseDir === "string") {
+      resolvedBaseDir = resolve(options.baseDir);
+    } else {
+      resolvedBaseDir = resolve(fileURLToPath(options.baseDir));
+    }
+
+    let resolvedPath: string;
+    if (typeof path === "string") {
+      resolvedPath = resolve(path);
+    } else if (path.protocol === "file:") {
+      resolvedPath = resolve(fileURLToPath(path));
+    } else {
+      resolvedPath = resolve(path.href);
+    }
+
+    const rel = relative(resolvedBaseDir, resolvedPath);
+    // If the path starts with '..' or is an absolute path (on Windows 'C:\' etc if different drive), it escaped the baseDir.
+    // If the relative path starts with '..' (or is just '..') or is an absolute path, it escaped the baseDir.
+    // Use sep to correctly identify directory boundaries (e.g. '../') rather than files that just start with '..' (e.g. '..hidden_file').
+    const { sep } = await import("node:path");
+    if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+      throw new Error(
+        `Path traversal detected: ${String(path)} is outside base directory ${String(options.baseDir)}`,
+      );
+    }
   }
 
   // 2. Bun (Local Files & file: URLs)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -53,9 +53,7 @@ export type StandardResult<T> =
  */
 export interface StandardSchema<T = unknown> {
   readonly "~standard": {
-    validate(
-      value: unknown,
-    ): StandardResult<T> | Promise<StandardResult<T>>;
+    validate(value: unknown): StandardResult<T> | Promise<StandardResult<T>>;
   };
 }
 
@@ -106,10 +104,7 @@ function throwValidationError(issues: ReadonlyArray<StandardIssue>): never {
  * @throws {ValidationError} if validation fails.
  * @throws {ValidationError} if `schema` does not implement Standard Schema.
  */
-export function validate<T>(
-  data: unknown,
-  schema: StandardSchema<T>,
-): T | Promise<T> {
+export function validate<T>(data: unknown, schema: StandardSchema<T>): T | Promise<T> {
   const std = (schema as Record<string, unknown>)["~standard"] as
     | { validate?: (v: unknown) => unknown }
     | undefined;
@@ -122,9 +117,7 @@ export function validate<T>(
     );
   }
 
-  const out = std.validate(data) as
-    | StandardResult<T>
-    | Promise<StandardResult<T>>;
+  const out = std.validate(data) as StandardResult<T> | Promise<StandardResult<T>>;
 
   if (isPromise<StandardResult<T>>(out)) {
     return out.then((r) => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -105,7 +105,7 @@ function throwValidationError(issues: ReadonlyArray<StandardIssue>): never {
  * @throws {ValidationError} if `schema` does not implement Standard Schema.
  */
 export function validate<T>(data: unknown, schema: StandardSchema<T>): T | Promise<T> {
-  const std = (schema as Record<string, unknown>)["~standard"] as
+  const std = (schema as unknown as Record<string, unknown>)["~standard"] as
     | { validate?: (v: unknown) => unknown }
     | undefined;
 

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -100,4 +100,16 @@ describe("readFrontMatter", () => {
     const results = await readFrontMatterMany([]);
     expect(results).toEqual([]);
   });
+
+  it("should restrict file reading to baseDir", async () => {
+    const maliciousPath = resolve(join(TEST_DIR, "../../package.json"));
+    await expect(readFrontMatter(maliciousPath, { baseDir: TEST_DIR })).rejects.toThrow(
+      "Path traversal detected",
+    );
+  });
+
+  it("should allow file reading within baseDir", async () => {
+    const result = await readFrontMatter<{ title: string }>(FILE_1, { baseDir: TEST_DIR });
+    expect(result.data.title).toBe("Test 1");
+  });
 });


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Add baseDir path traversal protection

🚨 Severity: HIGH
💡 Vulnerability: The `readFileContent` and `readFrontMatter` utility functions allowed reading arbitrary files if user-supplied input was provided. Attackers could supply paths like `../../../../etc/passwd` to traverse outside the intended directory.
🎯 Impact: This could lead to a Local File Inclusion (LFI) or Path Traversal vulnerability, exposing sensitive server files.
🔧 Fix: Introduced a `baseDir` option in `ParseOptions` that strictly validates local file paths against the intended base directory using `node:path` resolving logic. The fix safely detects paths that resolve outside the target directory and throws an error without reading the file.
✅ Verification: Covered by unit tests in `tests/file.test.ts`. Verified by running test and lint suites locally.

---
*PR created automatically by Jules for task [5792589041765984130](https://jules.google.com/task/5792589041765984130) started by @murelux*