### PR TITLE
🛡️ Sentinel: [HIGH] Fix Local File Inclusion (Path Traversal) in `readFrontMatter`

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** The Cloudflare Worker implementation exposed all bound KV namespaces via a generic `/:namespace/:slug` route. This meant any internal KV namespace (e.g., `KV_SECRETS`) bound to the worker was publicly accessible if the attacker guessed the namespace name.
 **Learning:** Dynamic resource mapping (like `/:namespace` -> `KV_NAMESPACE`) is convenient but dangerous if it bypasses explicit access controls.
 **Prevention:** Always implement an allowlist for dynamic resource access. In this case, `ALLOWED_NAMESPACES` environment variable was added to restrict access to only intended public namespaces.
+
+## 2024-05-23 - [Core] Local File Inclusion / Path Traversal in readFrontMatter
+**Vulnerability:** The `readFrontMatter` utility allowed reading any local file accessible by the runtime user if no path sanitization was applied by the consumer. Attackers could exploit this using path traversal patterns (e.g., `../../etc/passwd`) or absolute paths if input to this function was user-controlled.
+**Learning:** File reading utilities in libraries should offer built-in boundary enforcement, as consumers often fail to implement robust sanitization themselves before passing paths down.
+**Prevention:** Added a `baseDir` configuration option to `ParseOptions` that verifies the fully resolved absolute target path securely falls within the specified base directory using proper path separator checking (to avoid prefix-matching directory escapes).

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,16 @@ export interface ParseOptions {
    * @default false
    */
   allowRemoteUrls?: boolean;
+
+  /**
+   * Restrict local file reads to a specific base directory to prevent
+   * path traversal vulnerabilities.
+   *
+   * When provided, `readFrontMatter` will verify that the resolved
+   * target path is contained within this `baseDir`. Reads outside
+   * this directory will throw an error.
+   */
+  baseDir?: string;
 }
 
 /**
@@ -569,6 +579,7 @@ export async function readFrontMatter<T = Record<string, unknown>>(
 ): Promise<ParseResult<T>> {
   const content = await readFileContent(path, {
     allowRemoteUrls: options?.allowRemoteUrls ?? false,
+    baseDir: options?.baseDir,
   });
   return parseFrontMatter<T>(content, options);
 }

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -121,6 +121,46 @@ export function isPrivateHostname(hostname: string): boolean {
 // File Content Reading
 // ---------------------------------------------------------------------------
 
+// Cache path/url imports
+let pathModule: typeof import("node:path") | undefined;
+let urlModule: typeof import("node:url") | undefined;
+
+/**
+ * Validates that a local file path falls within the allowed base directory.
+ * Prevents Path Traversal/LFI vulnerabilities.
+ */
+async function validateLocalFilePath(target: string | URL, baseDir: string): Promise<void> {
+  if (!pathModule) pathModule = await import("node:path");
+
+  let targetPath: string;
+  if (target instanceof URL) {
+    if (target.protocol !== "file:") {
+      throw new Error(`Invalid local URL protocol: ${target.protocol}`);
+    }
+    if (!urlModule) urlModule = await import("node:url");
+    targetPath = urlModule.fileURLToPath(target);
+  } else if (target.startsWith("file:")) {
+    if (!urlModule) urlModule = await import("node:url");
+    targetPath = urlModule.fileURLToPath(new URL(target));
+  } else {
+    targetPath = target;
+  }
+
+  const resolvedBase = pathModule.resolve(baseDir);
+  const resolvedTarget = pathModule.resolve(targetPath);
+
+  // The resolved target must start with the resolved base directory + path separator
+  // to ensure it's truly a child and not just a prefix-matching folder
+  // (e.g. base="/var/foo" shouldn't allow access to "/var/foo-bar")
+  const requiredPrefix = resolvedBase.endsWith(pathModule.sep)
+    ? resolvedBase
+    : resolvedBase + pathModule.sep;
+
+  if (!resolvedTarget.startsWith(requiredPrefix) && resolvedTarget !== resolvedBase) {
+    throw new Error(`Path traversal detected: Access to ${target} is denied outside baseDir`);
+  }
+}
+
 /**
  * Read content from a file path or URL.
  *
@@ -134,7 +174,7 @@ export function isPrivateHostname(hostname: string): boolean {
  */
 export async function readFileContent(
   path: string | URL,
-  options?: { allowRemoteUrls?: boolean },
+  options?: { allowRemoteUrls?: boolean; baseDir?: string },
 ): Promise<string> {
   // 1. Fetch (HTTP/HTTPS) - prioritize for all runtimes
   if (
@@ -147,6 +187,11 @@ export async function readFileContent(
       );
     }
     return fetchContent(path);
+  }
+
+  // Ensure path traversal validation runs for local files
+  if (options?.baseDir) {
+    await validateLocalFilePath(path, options.baseDir);
   }
 
   // 2. Bun (Local Files & file: URLs)

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -53,9 +53,7 @@ export type StandardResult<T> =
  */
 export interface StandardSchema<T = unknown> {
   readonly "~standard": {
-    validate(
-      value: unknown,
-    ): StandardResult<T> | Promise<StandardResult<T>>;
+    validate(value: unknown): StandardResult<T> | Promise<StandardResult<T>>;
   };
 }
 
@@ -106,10 +104,7 @@ function throwValidationError(issues: ReadonlyArray<StandardIssue>): never {
  * @throws {ValidationError} if validation fails.
  * @throws {ValidationError} if `schema` does not implement Standard Schema.
  */
-export function validate<T>(
-  data: unknown,
-  schema: StandardSchema<T>,
-): T | Promise<T> {
+export function validate<T>(data: unknown, schema: StandardSchema<T>): T | Promise<T> {
   const std = (schema as Record<string, unknown>)["~standard"] as
     | { validate?: (v: unknown) => unknown }
     | undefined;
@@ -122,9 +117,7 @@ export function validate<T>(
     );
   }
 
-  const out = std.validate(data) as
-    | StandardResult<T>
-    | Promise<StandardResult<T>>;
+  const out = std.validate(data) as StandardResult<T> | Promise<StandardResult<T>>;
 
   if (isPromise<StandardResult<T>>(out)) {
     return out.then((r) => {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -105,7 +105,7 @@ function throwValidationError(issues: ReadonlyArray<StandardIssue>): never {
  * @throws {ValidationError} if `schema` does not implement Standard Schema.
  */
 export function validate<T>(data: unknown, schema: StandardSchema<T>): T | Promise<T> {
-  const std = (schema as Record<string, unknown>)["~standard"] as
+  const std = (schema as Record<string | number | symbol, unknown>)["~standard"] as
     | { validate?: (v: unknown) => unknown }
     | undefined;
 

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -105,7 +105,7 @@ function throwValidationError(issues: ReadonlyArray<StandardIssue>): never {
  * @throws {ValidationError} if `schema` does not implement Standard Schema.
  */
 export function validate<T>(data: unknown, schema: StandardSchema<T>): T | Promise<T> {
-  const std = (schema as Record<string | number | symbol, unknown>)["~standard"] as
+  const std = (schema as unknown as Record<string, unknown>)["~standard"] as
     | { validate?: (v: unknown) => unknown }
     | undefined;
 

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -100,4 +100,48 @@ describe("readFrontMatter", () => {
     const results = await readFrontMatterMany([]);
     expect(results).toEqual([]);
   });
+
+  describe("Security: Local File Path Traversal (baseDir)", () => {
+    it("should allow reading a file within the baseDir", async () => {
+      const result = await readFrontMatter<{ title: string }>(FILE_1, { baseDir: TEST_DIR });
+      expect(result.data.title).toBe("Test 1");
+    });
+
+    it("should block reading a file outside the baseDir via relative paths", async () => {
+      const outsidePath = join(TEST_DIR, "..", "..", "package.json");
+      await expect(readFrontMatter(outsidePath, { baseDir: TEST_DIR })).rejects.toThrowError(
+        /Path traversal detected/,
+      );
+    });
+
+    it("should block reading a file outside the baseDir via absolute paths", async () => {
+      const absoluteOutsidePath = resolve(join(TEST_DIR, "..", "..", "package.json"));
+      await expect(
+        readFrontMatter(absoluteOutsidePath, { baseDir: TEST_DIR }),
+      ).rejects.toThrowError(/Path traversal detected/);
+    });
+
+    it("should block reading a file outside the baseDir via file: URLs", async () => {
+      const fileUrl = pathToFileURL(resolve(join(TEST_DIR, "..", "..", "package.json")));
+      await expect(readFrontMatter(fileUrl, { baseDir: TEST_DIR })).rejects.toThrowError(
+        /Path traversal detected/,
+      );
+    });
+
+    it("should reject prefix-matching directories that are not true children", async () => {
+      // Create a sibling directory that shares the prefix of TEST_DIR
+      const siblingDir = `${TEST_DIR}-sibling`;
+      const siblingFile = join(siblingDir, "sibling.md");
+      await mkdir(siblingDir, { recursive: true });
+      await writeFile(siblingFile, "---\ntitle: Sibling\n---\nBody");
+
+      try {
+        await expect(readFrontMatter(siblingFile, { baseDir: TEST_DIR })).rejects.toThrowError(
+          /Path traversal detected/,
+        );
+      } finally {
+        await rm(siblingDir, { recursive: true, force: true });
+      }
+    });
+  });
 });


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `readFrontMatter` and `readFrontMatterMany` lacked path traversal boundaries. When provided with un-sanitized user input, it could allow an attacker to read arbitrary local files outside of the intended directory (Local File Inclusion / LFI) by using absolute paths or path traversal syntax like `../../etc/passwd`.
🎯 **Impact:** Potential leakage of sensitive system files, environment variables, or private source code if consumers pass un-sanitized paths directly to `readFrontMatter`.
🔧 **Fix:** Introduced an optional `baseDir` configuration option to `ParseOptions`. When provided, `readFileContent` will explicitly resolve the absolute path and ensure it starts securely within the absolute path of the `baseDir`, mitigating path traversal and directory prefix spoofing.
✅ **Verification:** Added comprehensive test cases to `tests/file.test.ts` to assert that path traversal using relative and absolute paths, as well as `file://` protocols are correctly intercepted. Run `pnpm test` to verify.

---
*PR created automatically by Jules for task [18191632922303163897](https://jules.google.com/task/18191632922303163897) started by @murelux*